### PR TITLE
Fix symbol file and module name

### DIFF
--- a/Custom/DOPModule/CMakeLists.txt
+++ b/Custom/DOPModule/CMakeLists.txt
@@ -2,7 +2,7 @@
 # from the hello plugin.
 if( NOT LLVM_REQUIRES_RTTI )
   if( NOT LLVM_REQUIRES_EH )
-    set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/SeeBranch.exports)
+    set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/DOPModule.exports)
   endif()
 endif()
 
@@ -10,6 +10,6 @@ if(WIN32 OR CYGWIN)
   set(LLVM_LINK_COMPONENTS Core Support)
 endif()
 
-add_llvm_loadable_module( LLVMSeeBranch
+add_llvm_loadable_module( LLVMDOPModule
   DOPModule.cpp
   )


### PR DESCRIPTION
Fixes symbol file name to resolve build failure caused by referencing the non-existent `SeeBranch.exports` file (Issue #1)